### PR TITLE
meta: fix licensing in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://midtrans.com",
     "version": "2.3.2",
     "type": "library",
-    "license":"GPL-3.0",
+    "license":"MIT",
     "authors": [
         {
             "name": "Andri Setiawan",


### PR DESCRIPTION
The metadata between [LICENSE](https://github.com/Midtrans/midtrans-php/commit/f9ce9282b273e7fdf5f0727cefed3c3bb4e0c322) file and composer.json license key does not
match. This commit changes it.